### PR TITLE
Fix bundle identifier to app.alfred.

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>app.alfredapp.stephenc.venturaprefpanes</string>
+	<string>app.alfred.stephenc.venturaprefpanes</string>
 	<key>category</key>
 	<string>Utilities</string>
 	<key>connections</key>


### PR DESCRIPTION
[Packaged Workflow](https://github.com/Stephen-Lon/Alfred-workflow-open-macos-settings-panes/files/10355031/Open.macOS.Settings.Panes.alfredworkflow.zip) for release.