### PR TITLE
Add direct link to Sharing → Remote Login

### DIFF
--- a/syset.sh
+++ b/syset.sh
@@ -664,6 +664,17 @@ cat <<EOF
       }
     },
     {
+      "uid": "Sharing → Remote Login",
+      "title": "Sharing → Remote Login",
+      "match": "sharing remote login ssh",
+      "subtitle": "Open the 'Sharing → Remote Login' pane",
+      "arg": "x-apple.systempreferences:com.apple.preferences.sharing?Services_RemoteLogin",
+      "autocomplete": "Sharing → Remote Login",
+      "icon": {
+        "path": "./Images/Sharing.png"
+      }
+    },
+    {
       "uid": "Sharing → Screen Sharing",
       "title": "Sharing → Screen Sharing",
       "subtitle": "Open the 'Sharing → Screen Sharing' pane",


### PR DESCRIPTION
Small addition adding a direct link to the Remote Login (aka SSH) section:

<img width=600 src=https://github.com/user-attachments/assets/ce4eb839-9920-4cf4-a525-069f5d531b4a>

I also added a `{ "match": ... }` key to the JSON so you can find it easier by keyword. 

@Stephen-Lon I highly recommend changing the default match mode to **Word matching - Any order** so the match key works properly (I can't do this as part of the PR because the repo doesn't seem to contain the `info.plist` for v3.1...)

<img width=500 src=https://github.com/user-attachments/assets/bdf4be10-923c-46a8-b08f-ce3ee492651e>
