### PR TITLE
feat: add `Input Sources` shortcut & adjust `Modifier Keys` label

### DIFF
--- a/syset.sh
+++ b/syset.sh
@@ -334,6 +334,26 @@ cat <<EOF
       }
     },
     {
+      "uid": "Keyboard → Shortcuts",
+      "title": "Keyboard → Shortcuts",
+      "subtitle": "Open the 'Keyboard → Shortcuts' pane",
+      "arg": "x-apple.systempreferences:com.apple.preference.keyboard?Shortcuts",
+      "autocomplete": "Keyboard → Shortcuts",
+      "icon": {
+        "path": "./Images/Keyboard.png"
+      }
+    },
+    {
+      "uid": "Keyboard → Input Sources",
+      "title": "Keyboard → Shortcuts",
+      "subtitle": "Open the 'Keyboard → Input Sources' pane",
+      "arg": "x-apple.systempreferences:com.apple.preference.keyboard?InputSources",
+      "autocomplete": "Keyboard → Input Sources",
+      "icon": {
+        "path": "./Images/Keyboard.png"
+      }
+    },
+    {
       "uid": "Keyboard → Text Replacements",
       "title": "Keyboard → Text Replacements",
       "subtitle": "Open the 'Keyboard → Text Replacements' pane",

--- a/syset.sh
+++ b/syset.sh
@@ -314,31 +314,21 @@ cat <<EOF
       }
     },
     {
-      "uid": "Keyboard → Function Keys",
-      "title": "Keyboard → Function Keys",
+      "uid": "Keyboard → Shortcuts → Function Keys",
+      "title": "Keyboard → Shortcuts → Function Keys",
       "subtitle": "Open the 'Keyboard → Function Keys' pane",
       "arg": "x-apple.systempreferences:com.apple.Keyboard-Settings.extension?FunctionKeys",
-      "autocomplete": "Keyboard → Function Keys",
+      "autocomplete": "Keyboard → Shortcuts → Function Keys",
       "icon": {
         "path": "./Images/Keyboard.png"
       }
     },
     {
-      "uid": "Keyboard → Modifier Keys",
-      "title": "Keyboard → Modifier Keys",
+      "uid": "Keyboard → Shortcuts → Modifier Keys",
+      "title": "Keyboard → Shortcuts → Modifier Keys",
       "subtitle": "Open the 'Keyboard → Modifier Keys' pane",
       "arg": "x-apple.systempreferences:com.apple.preference.keyboard?Shortcuts",
-      "autocomplete": "Keyboard → Modifier Keys",
-      "icon": {
-        "path": "./Images/Keyboard.png"
-      }
-    },
-    {
-      "uid": "Keyboard → Shortcuts",
-      "title": "Keyboard → Shortcuts",
-      "subtitle": "Open the 'Keyboard → Shortcuts' pane",
-      "arg": "x-apple.systempreferences:com.apple.preference.keyboard?Shortcuts",
-      "autocomplete": "Keyboard → Shortcuts",
+      "autocomplete": "Keyboard → Shortcuts → Modifier Keys",
       "icon": {
         "path": "./Images/Keyboard.png"
       }


### PR DESCRIPTION
- `Input Sources` shortcut added
- `Modifier Keys` and `Function Keys` label have been updated to included `Shortcuts`, the menu they are located it. Right now, using `syset shortcut` yields no results, even though both panes are inside `Keyword → Shortcut`. Adding `Shortcut` to the label fixes that and makes them findable.